### PR TITLE
Support for async/thenable functions to be handed

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,8 +306,7 @@ class RavenLambdaWrapper {
 
 			if (!ravenInstalled) {
 				// Directly invoke the original handler
-				handler(event, context, callback);
-				return;
+				return handler(event, context, callback);
 			}
 
 			context.done    = wrapCallback(pluginConfig, context.done.bind(context));
@@ -391,7 +390,7 @@ class RavenLambdaWrapper {
 					}
 
 					// And finally invoke the original handler code
-					handler(event, context, callback);
+					return handler(event, context, callback);
 				}
 				catch (err) {
 					// Catch and log synchronous exceptions thrown by the handler


### PR DESCRIPTION
Returning the result of the handed function we allow to deal with async functions. Now, `RavenLambdaWrapper.handler`will return a Promise, and the caller will be able to decide what to do with that Promise. If the handler function is a sync function, the behaviour will be equal to the "traditional" one, nothing changes.

Until now, if we try to wrap an async function, the function is goig to be launched, but we don't have any options to wait for it. With this change, we'll be able to do something like this:

```
const myHandler = async function(event, context, callback) { .... }
const wrapped = RavenLambdaWrapper.handler(Raven, myHandler);

await wrapped(event, context, callback);
console.log('After handler...');
```
Or:
```
const promise = wrapped(event, context, callback);
promise.then(() => console.log('After handler...'));
```