### PR TITLE
Fixed the problem that the async function times out

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "sentry",
     "getsentry.com"
   ],
+  "scripts": {
+    "test": "mocha src/*.test.js"
+  },
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -402,7 +402,7 @@ class RavenLambdaWrapper {
 
 					// And finally invoke the original handler code
 					const promise = handler(event, context, callback);
-					if (promise && _.isFunction(promise.then) && !callback) {
+					if (promise && _.isFunction(promise.then)) {
 						// don't forget to stop timers
 						return promise
 						.then((...data) => {
@@ -422,6 +422,9 @@ class RavenLambdaWrapper {
 							}
 						});
 					}
+					// Returning non-Promise values would be meaningless for lambda.
+					// But inherit the behavior of the original handler.
+					return promise;
 				}
 				catch (err) {
 					// Catch and log synchronous exceptions thrown by the handler

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -147,7 +147,7 @@ describe("RavenLambdaWrapper", () => {
 				};
 
 				const wrappedHandler = RavenLambdaWrapper.handler(RavenMock, handler);
-				return expect(wrappedHandler(mockEvent, mockContext)).to.eventually.be.fulfilled
+				return expect(wrappedHandler(mockEvent, mockContext, sinon.stub())).to.eventually.be.fulfilled
 				.then(result => {
 					expect(result).to.have.property("message").that.is.a("string");
 				});
@@ -159,7 +159,7 @@ describe("RavenLambdaWrapper", () => {
 				};
 
 				const wrappedHandler = RavenLambdaWrapper.handler(RavenMock, handler);
-				return expect(wrappedHandler(mockEvent, mockContext)).to.eventually.be.rejectedWith("Test Error");
+				return expect(wrappedHandler(mockEvent, mockContext, sinon.stub())).to.eventually.be.rejectedWith("Test Error");
 			});
 		});
 	});
@@ -314,7 +314,7 @@ describe("RavenLambdaWrapper", () => {
 				};
 
 				const wrappedHandler = RavenLambdaWrapper.handler(RavenMock, handler);
-				return expect(wrappedHandler(mockEvent, mockContext)).to.eventually.be.fulfilled
+				return expect(wrappedHandler(mockEvent, mockContext, sinon.stub())).to.eventually.be.fulfilled
 				.then(result => {
 					expect(result).to.have.property("message").that.is.a("string");
 				});
@@ -326,7 +326,7 @@ describe("RavenLambdaWrapper", () => {
 				};
 
 				const wrappedHandler = RavenLambdaWrapper.handler(RavenMock, handler);
-				return expect(wrappedHandler(mockEvent, mockContext)).to.eventually.be.rejectedWith("Test Error");
+				return expect(wrappedHandler(mockEvent, mockContext, sinon.stub())).to.eventually.be.rejectedWith("Test Error");
 			});
 
 			it("should capture rejection", () => {
@@ -336,7 +336,7 @@ describe("RavenLambdaWrapper", () => {
 
 				const wrappedHandler = RavenLambdaWrapper.handler(RavenMock, handler);
 				const spy = sandbox.spy(RavenMock, "captureException");
-				return expect(wrappedHandler(mockEvent, mockContext)).to.eventually.be.rejectedWith("Test Error")
+				return expect(wrappedHandler(mockEvent, mockContext, sinon.stub())).to.eventually.be.rejectedWith("Test Error")
 				.then(() => {
 					expect(spy).to.be.calledOnce;
 					expect(spy).to.be.calledWith(sinon.match.instanceOf(Error).and(sinon.match.has("message", "Test Error")));


### PR DESCRIPTION
I fixed the problem that the async function times out.

The cause is the following line.
```javascript
if (promise && _.isFunction(promise.then) && !callback) {
```

`callback` is always given by lambda. (even if it is `nodejs8.10`)
So `!callback` never becomes true, the handler does not return `promise`.