### PR TITLE
Avoid sending large payload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 	function timeoutWarningFunc(cb) {
 		const Raven = pluginConfig.ravenClient;
 		if (pluginConfig.printEventToStdout) {
-			console.log("Processing event for timeout warning:", event);
+			console.log("Processing event for timeout warning: " + JSON.stringify(event));
 		}
 		ravenInstalled && Raven.captureMessage("Function Execution Time Warning", {
 			level: "warning",
@@ -153,7 +153,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 	function timeoutErrorFunc(cb) {
 		const Raven = pluginConfig.ravenClient;
 		if (pluginConfig.printEventToStdout) {
-			console.log("Processing event for timeout error:", event);
+			console.log("Processing event for timeout error: " + JSON.stringify(event));
 		}
 		ravenInstalled && Raven.captureMessage("Function Timed Out", {
 			level: "error",
@@ -168,7 +168,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 		const p = (used / memoryLimit);
 		if (p >= 0.75) {
 			if (pluginConfig.printEventToStdout) {
-				console.log("Processing event for memory error:", event);
+				console.log("Processing event for memory error: " + JSON.stringify(event));
 			}
 			const Raven = pluginConfig.ravenClient;
 			ravenInstalled && Raven.captureMessage("Low Memory Warning", {
@@ -440,7 +440,7 @@ class RavenLambdaWrapper {
 						.catch(err => {
 							clearTimers();
 							if (pluginConfig.printEventToStdout) {
-								console.log("Processing event error exception:", event);
+								console.log("Processing event error exception: " + JSON.stringify(event));
 							}
 							if (ravenInstalled && err && pluginConfig.captureErrors) {
 								const Raven = pluginConfig.ravenClient;

--- a/src/index.js
+++ b/src/index.js
@@ -290,9 +290,9 @@ class RavenLambdaWrapper {
 			captureErrors:              parseBoolean(_.get(process.env, "SENTRY_CAPTURE_ERRORS"),    true),
 			captureUnhandledRejections: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_UNHANDLED"), true),
 			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
-			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
-			printEventToStdout: 				parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
-			filterEventsFields: 				_.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
+			captureTimeoutWarnings:			parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
+			printEventToStdout:					parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
+			filterEventsFields:					_.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
 			ravenClient: null
 		};
 

--- a/src/index.js
+++ b/src/index.js
@@ -133,7 +133,7 @@ let memoryWatch, timeoutWarning, timeoutError;
  * @param {Object} lambdaContext
  * @param {Object} event
  */
-function installTimers(pluginConfig, lambdaContext,event) {
+function installTimers(pluginConfig, lambdaContext, event) {
 	const timeRemaining = lambdaContext.getRemainingTimeInMillis();
 	const memoryLimit = lambdaContext.memoryLimitInMB;
 
@@ -191,8 +191,11 @@ function installTimers(pluginConfig, lambdaContext,event) {
 
 	if (pluginConfig.captureTimeoutWarnings) {
 		// We schedule the warning at half the maximum execution time and
-		// the error a few milliseconds before the actual timeout happens.
 		timeoutWarning = setTimeout(timeoutWarningFunc, timeRemaining / 2);
+	}
+
+	if (pluginConfig.captureTimeoutErrors) {
+		// the error a few milliseconds before the actual timeout happens.
 		timeoutError = setTimeout(timeoutErrorFunc, Math.max(timeRemaining - 500, 0));
 	}
 
@@ -280,7 +283,8 @@ class RavenLambdaWrapper {
 	 * @param {boolean} [pluginConfig.captureErrors] - capture Lambda errors (defaults to `true`)
 	 * @param {boolean} [pluginConfig.captureUnhandledRejections] - capture unhandled exceptions (defaults to `true`)
 	 * @param {boolean} [pluginConfig.captureMemoryWarnings] - monitor memory usage (defaults to `true`)
-	 * @param {boolean} [pluginConfig.captureTimeoutWarnings] - monitor execution timeouts (defaults to `true`)
+	 * @param {boolean} [pluginConfig.captureTimeoutWarnings] - monitor execution timeouts warnings (defaults to `true`)
+	 * @param {boolean} [pluginConfig.captureTimeoutErrors] - monitor execution timeouts errors (defaults to `true`)
  	 * @param {boolean} [pluginConfig.printEventToStdout] - print the event with console log (defaults to `false`)
 	 * @param {boolean} [pluginConfig.filterEventsFields] - filter out list of fields from the event data (defaults to ''.Example for not empty:'body,headers')
 	 * @param {Function} handler - Original Lambda function handler
@@ -301,6 +305,7 @@ class RavenLambdaWrapper {
 			captureUnhandledRejections: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_UNHANDLED"), true),
 			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
 			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
+			captureTimeoutErrors:       parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS_ERRORS"),  true),
 			printEventToStdout:         parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
 			filterEventsFields:         _.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
 			ravenClient: null

--- a/src/index.js
+++ b/src/index.js
@@ -290,8 +290,8 @@ class RavenLambdaWrapper {
 			captureErrors:              parseBoolean(_.get(process.env, "SENTRY_CAPTURE_ERRORS"),    true),
 			captureUnhandledRejections: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_UNHANDLED"), true),
 			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
-			captureTimeoutWarnings:			parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
-			printEventToStdout:					parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
+			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
+			printEventToStdout:         parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
 			filterEventsFields:					_.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
 			ravenClient: null
 		};

--- a/src/index.js
+++ b/src/index.js
@@ -245,10 +245,10 @@ function wrapCallback(pluginConfig, cb) {
  */
 function parseBoolean(value, defaultValue) {
 	const v = String(value).trim().toLowerCase();
-	if (["true", "t", "1", "yes", "y"].includes(v)) {
+	if ([ "true", "t", "1", "yes", "y" ].includes(v)) {
 		return true;
 	}
-	else if (["false", "f", "0", "no", "n"].includes(v)) {
+	else if ([ "false", "f", "0", "no", "n" ].includes(v)) {
 		return false;
 	}
 	else {
@@ -285,12 +285,12 @@ class RavenLambdaWrapper {
 		}
 
 		const pluginConfigDefaults = {
-			autoBreadcrumbs: parseBoolean(_.get(process.env, "SENTRY_AUTO_BREADCRUMBS"), true),
-			filterLocal: parseBoolean(_.get(process.env, "SENTRY_FILTER_LOCAL"), true),
-			captureErrors: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_ERRORS"), true),
+			autoBreadcrumbs:            parseBoolean(_.get(process.env, "SENTRY_AUTO_BREADCRUMBS"),  true),
+			filterLocal:                parseBoolean(_.get(process.env, "SENTRY_FILTER_LOCAL"),      true),
+			captureErrors:              parseBoolean(_.get(process.env, "SENTRY_CAPTURE_ERRORS"),    true),
 			captureUnhandledRejections: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_UNHANDLED"), true),
-			captureMemoryWarnings: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"), true),
-			captureTimeoutWarnings: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"), true),
+			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
+			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
 			filterEventsFields: _.get(process.env, "SENTRY_FILTER_EVENT_FIELDS",""),
 			printEventToStdout: parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
 			ravenClient: null
@@ -418,26 +418,25 @@ class RavenLambdaWrapper {
 					if (promise && _.isFunction(promise.then)) {
 						// don't forget to stop timers
 						return promise
-							.then((...data) => {
-								clearTimers();
-								return Promise.resolve(...data);
-							})
-							.catch(err => {
-								clearTimers();
-								if (pluginConfig.printEventToStdout) {
-									console.log("Processing event:", event);
-								}
-								if (ravenInstalled && err && pluginConfig.captureErrors) {
-									const Raven = pluginConfig.ravenClient;
-									return new Promise((resolve, reject) => Raven.captureException(err, {}, () => {
-
-										reject(err);
-									}));
-								}
-								else {
-									return Promise.reject(err);
-								}
-							});
+						.then((...data) => {
+							clearTimers();
+							return Promise.resolve(...data);
+						})
+						.catch(err => {
+							clearTimers();
+							if (pluginConfig.printEventToStdout) {
+								console.log("Processing event:", event);
+							}
+							if (ravenInstalled && err && pluginConfig.captureErrors) {
+								const Raven = pluginConfig.ravenClient;
+								return new Promise((resolve, reject) => Raven.captureException(err, {}, () => {
+									reject(err);
+								}));
+							}
+							else {
+								return Promise.reject(err);
+							}
+						});
 					}
 					// Returning non-Promise values would be meaningless for lambda.
 					// But inherit the behavior of the original handler.

--- a/src/index.js
+++ b/src/index.js
@@ -291,8 +291,8 @@ class RavenLambdaWrapper {
 			captureUnhandledRejections: parseBoolean(_.get(process.env, "SENTRY_CAPTURE_UNHANDLED"), true),
 			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
 			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
-			filterEventsFields: _.get(process.env, "SENTRY_FILTER_EVENT_FIELDS",""),
-			printEventToStdout: parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
+			printEventToStdout: 				parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
+			filterEventsFields: 				_.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
 			ravenClient: null
 		};
 
@@ -332,10 +332,10 @@ class RavenLambdaWrapper {
 
 			// filter out no needed fields from event
 			const filterEventsFieldsArray = pluginConfig.filterEventsFields.split(",");
-			const eventForAdditionalContext = JSON.parse(JSON.stringify(event));
+			const eventForAdditionalContext = Object.assign({}, event);
 			filterEventsFieldsArray.forEach(field => {
 				if (eventForAdditionalContext[field.trim()]) {
-					delete eventForAdditionalContext[field.trim()]
+					delete eventForAdditionalContext[field.trim()];
 				}
 			});
 

--- a/src/index.js
+++ b/src/index.js
@@ -271,8 +271,8 @@ class RavenLambdaWrapper {
 	 * @param {boolean} [pluginConfig.captureUnhandledRejections] - capture unhandled exceptions (defaults to `true`)
 	 * @param {boolean} [pluginConfig.captureMemoryWarnings] - monitor memory usage (defaults to `true`)
 	 * @param {boolean} [pluginConfig.captureTimeoutWarnings] - monitor execution timeouts (defaults to `true`)
+ 	 * @param {boolean} [pluginConfig.printEventToStdout] - print the event with console log (defaults to `false`)
 	 * @param {boolean} [pluginConfig.filterEventsFields] - filter out list of fields from the event data (defaults to ''.Example for not empty:'body,headers')
-	 * @param {boolean} [pluginConfig.printEventToStdout] - print the event with console log (defaults to `[]`)
 	 * @param {Function} handler - Original Lambda function handler
 	 * @return {Function} - Wrapped Lambda function handler with Sentry instrumentation
 	 */

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 	function timeoutWarningFunc(cb) {
 		const Raven = pluginConfig.ravenClient;
 		if (pluginConfig.printEventToStdout) {
-			console.log("Processing event for timeout warning: " + JSON.stringify(event));
+			console.log("Processing event for timeout warning:", event);
 		}
 		ravenInstalled && Raven.captureMessage("Function Execution Time Warning", {
 			level: "warning",
@@ -153,7 +153,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 	function timeoutErrorFunc(cb) {
 		const Raven = pluginConfig.ravenClient;
 		if (pluginConfig.printEventToStdout) {
-			console.log("Processing event for timeout error: " + JSON.stringify(event));
+			console.log("Processing event for timeout error:", event);
 		}
 		ravenInstalled && Raven.captureMessage("Function Timed Out", {
 			level: "error",
@@ -168,7 +168,7 @@ function installTimers(pluginConfig, lambdaContext, event) {
 		const p = (used / memoryLimit);
 		if (p >= 0.75) {
 			if (pluginConfig.printEventToStdout) {
-				console.log("Processing event for memory error: " + JSON.stringify(event));
+				console.log("Processing event for memory error:", event);
 			}
 			const Raven = pluginConfig.ravenClient;
 			ravenInstalled && Raven.captureMessage("Low Memory Warning", {
@@ -440,7 +440,7 @@ class RavenLambdaWrapper {
 						.catch(err => {
 							clearTimers();
 							if (pluginConfig.printEventToStdout) {
-								console.log("Processing event error exception: " + JSON.stringify(event));
+								console.log("Processing event error exception:", event);
 							}
 							if (ravenInstalled && err && pluginConfig.captureErrors) {
 								const Raven = pluginConfig.ravenClient;

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ class RavenLambdaWrapper {
 			captureMemoryWarnings:      parseBoolean(_.get(process.env, "SENTRY_CAPTURE_MEMORY"),    true),
 			captureTimeoutWarnings:     parseBoolean(_.get(process.env, "SENTRY_CAPTURE_TIMEOUTS"),  true),
 			printEventToStdout:         parseBoolean(_.get(process.env, "SENTRY_PRINT_EVENT_TO_STDOUT"), false),
-			filterEventsFields:					_.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
+			filterEventsFields:         _.get(process.env, "SENTRY_FILTER_EVENT_FIELDS", ""),
 			ravenClient: null
 		};
 
@@ -334,8 +334,8 @@ class RavenLambdaWrapper {
 			const filterEventsFieldsArray = pluginConfig.filterEventsFields.split(",");
 			const eventForAdditionalContext = Object.assign({}, event);
 			filterEventsFieldsArray.forEach(field => {
-				if (eventForAdditionalContext[field.trim()]) {
-					delete eventForAdditionalContext[field.trim()];
+			  if (eventForAdditionalContext[field.trim()]) {
+			    delete eventForAdditionalContext[field.trim()];
 				}
 			});
 


### PR DESCRIPTION
Add two new environment variables and plugins configs:

1. filterEventsFields - SENTRY_PRINT_EVENT_TO_STDOUT - filter out list of fields from the event data (defaults to ''.Example for not empty:'body,headers')

2. printEventToStdout - SENTRY_FILTER_EVENT_FIELDS - print the event with console log (defaults to `false`)